### PR TITLE
Add a transform to split paragraphs from text nodes

### DIFF
--- a/common-doc-split-paragraphs.asd
+++ b/common-doc-split-paragraphs.asd
@@ -1,0 +1,16 @@
+(defsystem common-doc-split-paragraphs
+  :author "Fernando Borretti <eudoxiahp@gmail.com>"
+  :maintainer "Fernando Borretti <eudoxiahp@gmail.com>"
+  :license "MIT"
+  :version "0.1"
+  :depends-on (:common-doc
+               :cl-ppcre)
+  :components ((:module "contrib"
+                :components
+                ((:module "split-paragraphs"
+                  :components
+                  ((:file "split-paragraphs"))))))
+  :description "Automatically generate paragraphs by splitting text nodes."
+  :long-description
+  #.(uiop:read-file-string
+     (uiop:subpathname *load-pathname* "contrib/split-paragraphs/README.md")))

--- a/contrib/split-paragraphs/README.md
+++ b/contrib/split-paragraphs/README.md
@@ -1,0 +1,10 @@
+# CommonDoc Split Paragraphs
+
+Generate paragraph nodes in a document by automatically splitting text nodes
+with double newlines. A useful pass to run after parsing from some input format.
+
+# License
+
+Copyright (c) 2015 Fernando Borretti
+
+Licensed under the MIT License.

--- a/contrib/split-paragraphs/split-paragraphs.lisp
+++ b/contrib/split-paragraphs/split-paragraphs.lisp
@@ -63,7 +63,7 @@ leaving a paragraph marker between each string."
                   (push +paragraph-marker+ output))))
           ;; If it's another node, add it to the output unconditionally
           (push elem output)))
-    output))
+    (reverse output)))
 
 (defun has-paragraph-markers (list)
   "Return whether a list has paragraph markers."
@@ -85,7 +85,7 @@ paragraph nodes."
                 (setf current-paragraph-contents nil))
               ;; Another node, so just push it in the paragraph
               (push elem current-paragraph-contents)))
-        output)
+        (reverse output))
       list))
 
 (defun split-and-group (list)
@@ -98,7 +98,8 @@ paragraph nodes."
 (defmethod split-paragraphs ((node content-node))
   "Split the paragraphs in a node's children."
   (setf (children node)
-        (split-and-group (children node))))
+        (split-and-group (children node)))
+  node)
 
 (defmethod split-paragraphs ((node document-node))
   "Regular nodes are just passed as-is."
@@ -107,4 +108,5 @@ paragraph nodes."
 (defmethod split-paragraphs ((doc document))
   "Split paragraphs in a document's children."
   (setf (children doc)
-        (split-and-group (children doc))))
+        (split-and-group (children doc)))
+  node)

--- a/contrib/split-paragraphs/split-paragraphs.lisp
+++ b/contrib/split-paragraphs/split-paragraphs.lisp
@@ -23,3 +23,24 @@ string if it has none."
   (if (has-paragraph-separator string)
       (ppcre:split "\\n\\n" string)
       string))
+
+(defun excise-paragraph-separators (list)
+  "Take a list of strings or other elements. Separate strings by paragraphs,
+leaving a paragraph marker between each string."
+  (let ((output (list)))
+    (loop for elem in list do
+      (if (stringp elem)
+          ;; If it's a string, split it by its separator
+          (let ((split (split-paragraph elem)))
+            (if (stringp split)
+                ;; Just a regular string with no separators, add it to the
+                ;; output
+                (push split output)
+                ;; A list of text nodes, add each to the output, followed by a
+                ;; paragraph separator marker
+                (loop for text in split do
+                  (push text output)
+                  (push +paragraph-marker+ output))))
+          ;; If it's another node, add it to the output unconditionally
+          (push elem output)))
+    output))

--- a/contrib/split-paragraphs/split-paragraphs.lisp
+++ b/contrib/split-paragraphs/split-paragraphs.lisp
@@ -1,10 +1,13 @@
 (in-package :cl-user)
 (defpackage common-doc.split-paragraphs
   (:use :cl)
+  (:export :*paragraph-separator-regex*
+           :has-paragraph-separator
+           :split-paragraph)
   (:documentation "Main package of split-paragraphs."))
 (in-package :common-doc.split-paragraphs)
 
-(defparameter +paragraph-separator-regex+
+(defparameter *paragraph-separator-regex*
   (ppcre:create-scanner "\\n\\n")
   "A regular expression that matches double newlines.")
 
@@ -15,7 +18,7 @@ paragraphs.")
 
 (defun has-paragraph-separator (string)
   "Does string contain a paragraph separator?"
-  (if (ppcre:scan +paragraph-separator-regex+ string) t))
+  (if (ppcre:scan *paragraph-separator-regex* string) t))
 
 (defun split-paragraph (string)
   "Split a string by the separator into a list of strings, or return the intact

--- a/contrib/split-paragraphs/split-paragraphs.lisp
+++ b/contrib/split-paragraphs/split-paragraphs.lisp
@@ -1,0 +1,25 @@
+(in-package :cl-user)
+(defpackage common-doc.split-paragraphs
+  (:use :cl)
+  (:documentation "Main package of split-paragraphs."))
+(in-package :common-doc.split-paragraphs)
+
+(defparameter +paragraph-separator-regex+
+  (ppcre:create-scanner "\\n\\n")
+  "A regular expression that matches double newlines.")
+
+(defparameter +paragraph-marker+
+  :paragraph-split
+  "A marker that is inserted between strings after they are separated by
+paragraphs.")
+
+(defun has-paragraph-separator (string)
+  "Does string contain a paragraph separator?"
+  (if (ppcre:scan +paragraph-separator-regex+ string) t))
+
+(defun split-paragraph (string)
+  "Split a string by the separator into a list of strings, or return the intact
+string if it has none."
+  (if (has-paragraph-separator string)
+      (ppcre:split "\\n\\n" string)
+      string))


### PR DESCRIPTION
Basically, go through the document, and replace text nodes that have two consecutive newlines with proper paragraph nodes.
