### PR TITLE
Fixed constructors for WEB-LINK and DOCUMENT-LINK to fill metadata with necessary attributes.

### DIFF
--- a/t/common-doc.lisp
+++ b/t/common-doc.lisp
@@ -55,6 +55,25 @@
       (when (string= key "b")
         (is (equal value 2))))))
 
+(test web-link-metadata
+  ;; URI should be present not only as a slot, but also as
+  ;; an item in metadata hash-table, because Scriba's
+  ;; emitter takes attribute values from the metadata dictionary.
+  (let ((link (make-web-link "http://www.example.com" nil)))
+    (is (string= (get-meta link "uri")
+                 "http://www.example.com"))))
+
+
+(test document-link-metadata
+  ;; For DOCUMENT-LINK we also have to save  should be present not only as a slot, but also as
+  ;; an item in metadata hash-table, because Scriba's
+  ;; emitter takes attribute values from the metadata dictionary.
+  (let ((link (make-document-link "document-id" "reference-id" nil)))
+    (is (string= (get-meta link "doc")
+                 "document-id"))
+    (is (string= (get-meta link "id")
+                 "reference-id"))))
+
 (test nodes
   (is
    (eql (find-node "b")


### PR DESCRIPTION
This fixes links emitting by Scriba for the case when a WEB-LINK or a DOCUMENT-LINK was created using a constructor.

@eudoxia0 please, advise me what is the best strategy to fix the problem? I've commented my first attempt here: https://github.com/CommonDoc/common-doc/pull/26/files#diff-1df10903b05ac9f82a1904e20bbd18582495568eed10144e222700554cbc2d2fR12-R24